### PR TITLE
Provide support in `configure.sh` to specify an architecture flag

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,1 @@
+Andrew V. Jones, Vector Informatik

--- a/configure.sh
+++ b/configure.sh
@@ -8,6 +8,7 @@ gprof=no
 flto=no
 shared=no
 static=no
+arch=unknown
 
 #--------------------------------------------------------------------------#
 
@@ -27,6 +28,7 @@ where <option> is one of the following:
   -static           static compilation
   -g                compile with debugging support
   -c                check assertions even in optimized compilation
+  -m{32,64}         force 32-bit or 64-bit compilation
   -shared           shared library
   -asan             compile with -fsanitize=address -fsanitize-recover=address
   -gcov             compile with -fprofile-arcs -ftest-coverage
@@ -50,6 +52,8 @@ do
     -g) debug=yes;;
     -O) debug=no;;
     -c) check=yes;;
+    -m32|--m32) arch=32;;
+    -m64|--m64) arch=64;;
     -flto) flto=yes;;
     -shared) shared=yes;;
     -static) static=yes;;
@@ -70,6 +74,8 @@ if [ X"$CFLAGS" = X ]
 then
   [ $debug = unknown ] && debug=no
   CFLAGS="-W -Wall -Wextra -Wredundant-decls"
+  [ $arch = 32 ] && CFLAGS="$CFLAGS -m32"
+  [ $arch = 64 ] && CFLAGS="$CFLAGS -m64"
   [ $static = yes ] && CFLAGS="$CFLAGS -static"
   [ $shared = yes ] && CFLAGS="$CFLAGS -fPIC"
   if [ $debug = yes ]


### PR DESCRIPTION
Previously, it was not possible to specify a target architecture when compiling btor2tools. This PR brings across the functionality from Boolector to correct set the processor architecture.

Minor: it also introduces a CONTRIBUTORS file.