### PR TITLE
Port btorsim to C++

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,12 +4,13 @@ add_library(btor2parser
 target_include_directories(btor2parser PRIVATE .)
 
 add_executable(btorsim
-  btorsim/btorsim.c
+  btorsim/btorsim.cpp
   btorsim/btorsimbv.c
   btorsim/btorsimrng.c
 )
 target_include_directories(btorsim PRIVATE .)
 target_link_libraries(btorsim btor2parser)
+target_compile_options(btorsim PRIVATE -Wall)
 
 add_executable(catbtor catbtor.c)
 target_link_libraries(catbtor btor2parser)

--- a/src/btorsim/btorsim.cpp
+++ b/src/btorsim/btorsim.cpp
@@ -21,6 +21,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <string>
+
 #include "btor2parser/btor2parser.h"
 #include "btorsimbv.h"
 #include "btorsimrng.h"
@@ -30,7 +32,7 @@
 /*------------------------------------------------------------------------*/
 
 static void
-die (char *m, ...)
+die (const char* m, ...)
 {
   fflush (stdout);
   fputs ("*** 'btorsim' error: ", stderr);
@@ -46,7 +48,7 @@ static int32_t verbosity;
 static int32_t print_states;
 
 static void
-msg (int32_t level, char *m, ...)
+msg (int32_t level, const char* m, ...)
 {
   if (level > verbosity) return;
   assert (m);

--- a/src/btorsim/btorsim.cpp
+++ b/src/btorsim/btorsim.cpp
@@ -22,12 +22,11 @@
 #include <string.h>
 
 #include <string>
+#include <vector>
 
 #include "btor2parser/btor2parser.h"
 #include "btorsimbv.h"
 #include "btorsimrng.h"
-#include "util/btor2mem.h"
-#include "util/btor2stack.h"
 
 /*------------------------------------------------------------------------*/
 
@@ -138,27 +137,23 @@ static int32_t random_mode   = 0;
 
 static Btor2Parser *model;
 
-BTOR2_DECLARE_STACK (Btor2LinePtr, Btor2Line *);
+static std::vector<Btor2Line *> inputs;
+static std::vector<Btor2Line *> states;
+static std::vector<Btor2Line *> bads;
+static std::vector<Btor2Line *> constraints;
+static std::vector<Btor2Line *> justices;
 
-static Btor2LinePtrStack inputs;
-static Btor2LinePtrStack states;
-static Btor2LinePtrStack bads;
-static Btor2LinePtrStack constraints;
-static Btor2LinePtrStack justices;
-
-BTOR2_DECLARE_STACK (BtorLong, int64_t);
-
-static BtorLongStack reached_bads;
+static std::vector<int64_t> reached_bads;
 
 static int64_t constraints_violated = -1;
 static int64_t num_unreached_bads;
 
 static int64_t num_format_lines;
-static Btor2Line **inits;
-static Btor2Line **nexts;
+static std::vector<Btor2Line *> inits;
+static std::vector<Btor2Line *> nexts;
 
-static BtorSimBitVector **current_state;
-static BtorSimBitVector **next_state;
+static std::vector<BtorSimBitVector *> current_state;
+static std::vector<BtorSimBitVector *> next_state;
 
 static void
 parse_model_line (Btor2Line *l)
@@ -167,19 +162,19 @@ parse_model_line (Btor2Line *l)
   {
     case BTOR2_TAG_bad:
     {
-      int64_t i = (int64_t) BTOR2_COUNT_STACK (bads);
+      int64_t i = (int64_t) bads.size();
       msg (2, "bad %" PRId64 " at line %" PRId64, i, l->lineno);
-      BTOR2_PUSH_STACK (bads, l);
-      BTOR2_PUSH_STACK (reached_bads, -1);
+      bads.push_back(l);
+      reached_bads.push_back(-1);
       num_unreached_bads++;
     }
     break;
 
     case BTOR2_TAG_constraint:
     {
-      int64_t i = (int64_t) BTOR2_COUNT_STACK (constraints);
+      int64_t i = (int64_t) constraints.size();
       msg (2, "constraint %" PRId64 " at line %" PRId64, i, l->lineno);
-      BTOR2_PUSH_STACK (constraints, l);
+      constraints.push_back(l);
     }
     break;
 
@@ -187,12 +182,12 @@ parse_model_line (Btor2Line *l)
 
     case BTOR2_TAG_input:
     {
-      int64_t i = (int64_t) BTOR2_COUNT_STACK (inputs);
+      int64_t i = (int64_t) inputs.size();
       if (l->symbol)
         msg (2, "input %" PRId64 " '%s' at line %" PRId64, i, l->symbol, l->lineno);
       else
         msg (2, "input %" PRId64 " at line %" PRId64, i, l->lineno);
-      BTOR2_PUSH_STACK (inputs, l);
+      inputs.push_back(l);
     }
     break;
 
@@ -219,12 +214,12 @@ parse_model_line (Btor2Line *l)
 
     case BTOR2_TAG_state:
     {
-      int64_t i = (int64_t) BTOR2_COUNT_STACK (states);
+      int64_t i = (int64_t) states.size();
       if (l->symbol)
         msg (2, "state %" PRId64 " '%s' at line %" PRId64, i, l->symbol, l->lineno);
       else
         msg (2, "state %" PRId64 " at line %" PRId64, i, l->lineno);
-      BTOR2_PUSH_STACK (states, l);
+      states.push_back(l);
     }
     break;
 
@@ -303,26 +298,20 @@ parse_model_line (Btor2Line *l)
 static void
 parse_model ()
 {
-  BTOR2_INIT_STACK (inputs);
-  BTOR2_INIT_STACK (states);
-  BTOR2_INIT_STACK (bads);
-  BTOR2_INIT_STACK (justices);
-  BTOR2_INIT_STACK (reached_bads);
-  BTOR2_INIT_STACK (constraints);
   assert (model_file);
   model = btor2parser_new ();
   if (!btor2parser_read_lines (model, model_file))
     die ("parse error in '%s' at %s", model_path, btor2parser_error (model));
   num_format_lines = btor2parser_max_id (model);
-  BTOR2_CNEWN (inits, num_format_lines);
-  BTOR2_CNEWN (nexts, num_format_lines);
+  inits.resize(num_format_lines, nullptr);
+  nexts.resize(num_format_lines, nullptr);
   Btor2LineIterator it = btor2parser_iter_init (model);
   Btor2Line *line;
   while ((line = btor2parser_iter_next (&it))) parse_model_line (line);
 
-  for (int64_t i = 0; i < BTOR2_COUNT_STACK (states); i++)
+  for (size_t i = 0; i < states.size(); i++)
   {
-    Btor2Line *state = BTOR2_PEEK_STACK (states, i);
+    Btor2Line *state = states[i];
     if (!nexts[state->id])
     {
       msg (1, "state %d without next function", state->id);
@@ -572,9 +561,9 @@ initialize_inputs (int64_t k, int32_t randomize)
 {
   msg (1, "initializing inputs @%" PRId64, k);
   if (print_trace) printf ("@%" PRId64 "\n", k);
-  for (int64_t i = 0; i < BTOR2_COUNT_STACK (inputs); i++)
+  for (size_t i = 0; i < inputs.size(); i++)
   {
-    Btor2Line *input = BTOR2_PEEK_STACK (inputs, i);
+    Btor2Line *input = inputs[i];
     uint32_t width   = input->sort.bitvec.width;
     if (current_state[input->id]) continue;
     BtorSimBitVector *update;
@@ -585,7 +574,7 @@ initialize_inputs (int64_t k, int32_t randomize)
     update_current_state (input->id, update);
     if (print_trace)
     {
-      printf ("%" PRId64 " ", i);
+      printf ("%lu ", i);
       btorsim_bv_print_without_new_line (update);
       if (input->symbol) printf (" %s@%" PRId64, input->symbol, k);
       fputc ('\n', stdout);
@@ -598,9 +587,9 @@ initialize_states (int32_t randomly)
 {
   msg (1, "initializing states at #0");
   if (print_trace) printf ("#0\n");
-  for (int64_t i = 0; i < BTOR2_COUNT_STACK (states); i++)
+  for (size_t i = 0; i < states.size(); i++)
   {
-    Btor2Line *state = BTOR2_PEEK_STACK (states, i);
+    Btor2Line *state = states[i];
     assert (0 <= state->id), assert (state->id < num_format_lines);
     if (current_state[state->id]) continue;
     Btor2Line *init = inits[state->id];
@@ -623,7 +612,7 @@ initialize_states (int32_t randomly)
     update_current_state (state->id, update);
     if (print_trace && !init)
     {
-      printf ("%" PRId64 " ", i);
+      printf ("%lu ", i);
       btorsim_bv_print_without_new_line (update);
       if (state->symbol) printf (" %s#0", state->symbol);
       fputc ('\n', stdout);
@@ -653,9 +642,9 @@ simulate_step (int64_t k, int32_t randomize_states_that_are_inputs)
 #endif
     btorsim_bv_free (bv);
   }
-  for (int64_t i = 0; i < BTOR2_COUNT_STACK (states); i++)
+  for (size_t i = 0; i < states.size(); i++)
   {
-    Btor2Line *state = BTOR2_PEEK_STACK (states, i);
+    Btor2Line *state = states[i];
     assert (0 <= state->id), assert (state->id < num_format_lines);
     Btor2Line *next = nexts[state->id];
     BtorSimBitVector *update;
@@ -680,9 +669,9 @@ simulate_step (int64_t k, int32_t randomize_states_that_are_inputs)
 
   if (constraints_violated < 0)
   {
-    for (int64_t i = 0; i < BTOR2_COUNT_STACK (constraints); i++)
+    for (size_t i = 0; i < constraints.size(); i++)
     {
-      Btor2Line *constraint = BTOR2_PEEK_STACK (constraints, i);
+      Btor2Line *constraint = constraints[i];
       BtorSimBitVector *bv  = current_state[constraint->args[0]];
       if (!btorsim_bv_is_zero (bv)) continue;
       msg (1,
@@ -697,21 +686,21 @@ simulate_step (int64_t k, int32_t randomize_states_that_are_inputs)
 
   if (constraints_violated < 0)
   {
-    for (int64_t i = 0; i < BTOR2_COUNT_STACK (bads); i++)
+    for (size_t i = 0; i < bads.size(); i++)
     {
-      int64_t r = BTOR2_PEEK_STACK (reached_bads, i);
+      int64_t r = reached_bads[i];
       if (r >= 0) continue;
-      Btor2Line *bad       = BTOR2_PEEK_STACK (bads, i);
+      Btor2Line *bad       = bads[i];
       BtorSimBitVector *bv = current_state[bad->args[0]];
       if (btorsim_bv_is_zero (bv)) continue;
-      int64_t bound = BTOR2_PEEK_STACK (reached_bads, i);
+      int64_t bound = reached_bads[i];
       if (bound >= 0) continue;
-      BTOR2_POKE_STACK (reached_bads, i, k);
+      reached_bads[i] = k;
       assert (num_unreached_bads > 0);
       if (!--num_unreached_bads)
         msg (1,
              "all %" PRId64 " bad state properties reached",
-             (int64_t) BTOR2_COUNT_STACK (bads));
+             (int64_t) bads.size());
     }
   }
 }
@@ -722,9 +711,9 @@ transition (int64_t k)
   msg (1, "transition %" PRId64, k);
   for (int64_t i = 0; i < num_format_lines; i++) delete_current_state (i);
   if (print_trace && print_states) printf ("#%" PRId64 "\n", k);
-  for (int64_t i = 0; i < BTOR2_COUNT_STACK (states); i++)
+  for (size_t i = 0; i < states.size(); i++)
   {
-    Btor2Line *state = BTOR2_PEEK_STACK (states, i);
+    Btor2Line *state = states[i];
     assert (0 <= state->id), assert (state->id < num_format_lines);
     BtorSimBitVector *update = next_state[state->id];
     assert (update);
@@ -732,7 +721,7 @@ transition (int64_t k)
     next_state[state->id] = 0;
     if (print_trace && print_states)
     {
-      printf ("%" PRId64 " ", i);
+      printf ("%lu ", i);
       btorsim_bv_print_without_new_line (update);
       if (state->symbol) printf (" %s#%" PRId64, state->symbol, k);
       fputc ('\n', stdout);
@@ -743,22 +732,22 @@ transition (int64_t k)
 static void
 report ()
 {
-  if (verbosity && num_unreached_bads < BTOR2_COUNT_STACK (bads))
+  if (verbosity && num_unreached_bads < (int64_t) bads.size())
   {
     printf ("[btorsim] reached bad state properties {");
-    for (int64_t i = 0; i < BTOR2_COUNT_STACK (bads); i++)
+    for (size_t i = 0; i < bads.size(); i++)
     {
-      int64_t r = BTOR2_PEEK_STACK (reached_bads, i);
-      if (r >= 0) printf (" b%" PRId64 "@%" PRId64, i, r);
+      int64_t r = reached_bads[i];
+      if (r >= 0) printf (" b%lu@%" PRId64, i, r);
     }
     printf (" }\n");
   }
-  else if (!BTOR2_EMPTY_STACK (bads))
+  else if (!bads.empty())
     msg (1, "no bad state property reached");
 
   if (constraints_violated >= 0)
     msg (1, "constraints violated at time %" PRId64, constraints_violated);
-  else if (!BTOR2_EMPTY_STACK (constraints))
+  else if (!constraints.empty())
     msg (1, "constraints always satisfied");
 }
 
@@ -868,8 +857,8 @@ static int64_t count_unsat_witnesses;
 static int64_t count_unknown_witnesses;
 static int64_t count_witnesses;
 
-static BtorLongStack claimed_bad_witnesses;
-static BtorLongStack claimed_justice_witnesses;
+static std::vector<int64_t> claimed_bad_witnesses;
+static std::vector<int64_t> claimed_justice_witnesses;
 
 static int64_t
 parse_unsigned_number (int32_t *ch_ptr)
@@ -981,7 +970,7 @@ parse_state_part (int64_t k)
     charno            = 1;
     assert (lineno > 1);
     lineno--;
-    if (state_pos >= BTOR2_COUNT_STACK (states))
+    if (state_pos >= (int64_t) states.size())
       parse_error ("less than %" PRId64 " states defined", state_pos);
     if (BTOR2_EMPTY_STACK (symbol))
       msg (4,
@@ -996,7 +985,7 @@ parse_state_part (int64_t k)
            constant.start,
            symbol.start,
            k);
-    Btor2Line *state = BTOR2_PEEK_STACK (states, state_pos);
+    Btor2Line *state = states[state_pos];
     assert (state);
     if (strlen (constant.start) != state->sort.bitvec.width)
       charno = constant_columno,
@@ -1048,7 +1037,7 @@ parse_input_part (int64_t k)
     charno            = 1;
     assert (lineno > 1);
     lineno--;
-    if (input_pos >= BTOR2_COUNT_STACK (inputs))
+    if (input_pos >= (int64_t) inputs.size())
       parse_error ("less than %" PRId64 " defined", input_pos);
     if (BTOR2_EMPTY_STACK (symbol))
       msg (4,
@@ -1063,7 +1052,7 @@ parse_input_part (int64_t k)
            constant.start,
            symbol.start,
            k);
-    Btor2Line *input = BTOR2_PEEK_STACK (inputs, input_pos);
+    Btor2Line *input = inputs[input_pos];
     assert (input);
     if (strlen (constant.start) != input->sort.bitvec.width)
       charno = constant_columno,
@@ -1102,9 +1091,6 @@ parse_sat_witness ()
 
   msg (1, "parsing 'sat' witness %" PRId64, count_sat_witnesses);
 
-  BTOR2_INIT_STACK (claimed_bad_witnesses);
-  BTOR2_INIT_STACK (claimed_justice_witnesses);
-
   for (;;)
   {
     int32_t type = next_char ();
@@ -1127,12 +1113,12 @@ parse_sat_witness ()
     }
     if (type == 'b')
     {
-      if (bad >= BTOR2_COUNT_STACK (bads))
+      if (bad >= (int64_t) bads.size())
         parse_error ("invalid bad state property number %" PRId64, bad);
       msg (3,
            "... claims to be witness of bad state property number 'b%" PRId64 "'",
            bad);
-      BTOR2_PUSH_STACK (claimed_bad_witnesses, bad);
+      claimed_bad_witnesses.push_back(bad);
     }
     else
       parse_error ("can not handle justice properties yet");
@@ -1148,19 +1134,16 @@ parse_sat_witness ()
   report ();
   if (print_trace) printf (".\n"), fflush (stdout);
 
-  for (int64_t i = 0; i < BTOR2_COUNT_STACK (claimed_bad_witnesses); i++)
+  for (size_t i = 0; i < claimed_bad_witnesses.size(); i++)
   {
-    int64_t bad_pos = BTOR2_PEEK_STACK (claimed_bad_witnesses, i);
-    int64_t bound   = BTOR2_PEEK_STACK (reached_bads, bad_pos);
-    Btor2Line *l = BTOR2_PEEK_STACK (bads, bad_pos);
+    int64_t bad_pos = claimed_bad_witnesses[i];
+    int64_t bound   = reached_bads[bad_pos];
+    Btor2Line *l = bads[bad_pos];
     if (bound < 0)
       die ("claimed bad state property 'b%" PRId64 "' id %" PRId64 " not reached",
            bad_pos,
            l->id);
   }
-
-  BTOR2_RELEASE_STACK (claimed_bad_witnesses);
-  BTOR2_RELEASE_STACK (claimed_justice_witnesses);
 }
 
 static void
@@ -1359,14 +1342,14 @@ main (int32_t argc, char **argv)
   assert (model_path);
   msg (1, "reading BTOR model from '%s'", model_path);
   parse_model ();
-  if (fake_bad >= BTOR2_COUNT_STACK (bads))
+  if (fake_bad >= (int64_t) bads.size())
     die ("invalid faked bad state property number %" PRId64, fake_bad);
-  if (fake_justice >= BTOR2_COUNT_STACK (justices))
+  if (fake_justice >= (int64_t) justices.size())
     die ("invalid faked justice property number %" PRId64, fake_justice);
   if (close_model_file && fclose (model_file))
     die ("can not close model file '%s'", model_path);
-  BTOR2_CNEWN (current_state, num_format_lines);
-  BTOR2_CNEWN (next_state, num_format_lines);
+  current_state.resize(num_format_lines, nullptr);
+  next_state.resize(num_format_lines, nullptr);
   if (random_mode)
   {
     if (r < 0) r = 20;
@@ -1392,20 +1375,10 @@ main (int32_t argc, char **argv)
     if (close_witness_file && fclose (witness_file))
       die ("can not close witness file '%s'", witness_path);
   }
-  BTOR2_RELEASE_STACK (inputs);
-  BTOR2_RELEASE_STACK (states);
-  BTOR2_RELEASE_STACK (bads);
-  BTOR2_RELEASE_STACK (justices);
-  BTOR2_RELEASE_STACK (reached_bads);
-  BTOR2_RELEASE_STACK (constraints);
   btor2parser_delete (model);
-  BTOR2_DELETE (inits);
-  BTOR2_DELETE (nexts);
   for (int64_t i = 0; i < num_format_lines; i++)
     if (current_state[i]) btorsim_bv_free (current_state[i]);
   for (int64_t i = 0; i < num_format_lines; i++)
     if (next_state[i]) btorsim_bv_free (next_state[i]);
-  BTOR2_DELETE (current_state);
-  BTOR2_DELETE (next_state);
   return 0;
 }

--- a/src/btorsim/btorsim.cpp
+++ b/src/btorsim/btorsim.cpp
@@ -31,7 +31,7 @@
 /*------------------------------------------------------------------------*/
 
 static void
-die (const char* m, ...)
+die (const char *m, ...)
 {
   fflush (stdout);
   fputs ("*** 'btorsim' error: ", stderr);
@@ -47,7 +47,7 @@ static int32_t verbosity;
 static int32_t print_states;
 
 static void
-msg (int32_t level, const char* m, ...)
+msg (int32_t level, const char *m, ...)
 {
   if (level > verbosity) return;
   assert (m);
@@ -160,46 +160,48 @@ parse_model_line (Btor2Line *l)
 {
   switch (l->tag)
   {
-    case BTOR2_TAG_bad:
-    {
-      int64_t i = (int64_t) bads.size();
+    case BTOR2_TAG_bad: {
+      int64_t i = (int64_t) bads.size ();
       msg (2, "bad %" PRId64 " at line %" PRId64, i, l->lineno);
-      bads.push_back(l);
-      reached_bads.push_back(-1);
+      bads.push_back (l);
+      reached_bads.push_back (-1);
       num_unreached_bads++;
     }
     break;
 
-    case BTOR2_TAG_constraint:
-    {
-      int64_t i = (int64_t) constraints.size();
+    case BTOR2_TAG_constraint: {
+      int64_t i = (int64_t) constraints.size ();
       msg (2, "constraint %" PRId64 " at line %" PRId64, i, l->lineno);
-      constraints.push_back(l);
+      constraints.push_back (l);
     }
     break;
 
     case BTOR2_TAG_init: inits[l->args[0]] = l; break;
 
-    case BTOR2_TAG_input:
-    {
-      int64_t i = (int64_t) inputs.size();
+    case BTOR2_TAG_input: {
+      int64_t i = (int64_t) inputs.size ();
       if (l->symbol)
-        msg (2, "input %" PRId64 " '%s' at line %" PRId64, i, l->symbol, l->lineno);
+        msg (2,
+             "input %" PRId64 " '%s' at line %" PRId64,
+             i,
+             l->symbol,
+             l->lineno);
       else
         msg (2, "input %" PRId64 " at line %" PRId64, i, l->lineno);
-      inputs.push_back(l);
+      inputs.push_back (l);
     }
     break;
 
     case BTOR2_TAG_next: nexts[l->args[0]] = l; break;
 
-    case BTOR2_TAG_sort:
-    {
+    case BTOR2_TAG_sort: {
       switch (l->sort.tag)
       {
         case BTOR2_TAG_SORT_bitvec:
-          msg (
-              2, "sort bitvec %u at line %" PRId64, l->sort.bitvec.width, l->lineno);
+          msg (2,
+               "sort bitvec %u at line %" PRId64,
+               l->sort.bitvec.width,
+               l->lineno);
           break;
         case BTOR2_TAG_SORT_array:
         default:
@@ -212,14 +214,17 @@ parse_model_line (Btor2Line *l)
     }
     break;
 
-    case BTOR2_TAG_state:
-    {
-      int64_t i = (int64_t) states.size();
+    case BTOR2_TAG_state: {
+      int64_t i = (int64_t) states.size ();
       if (l->symbol)
-        msg (2, "state %" PRId64 " '%s' at line %" PRId64, i, l->symbol, l->lineno);
+        msg (2,
+             "state %" PRId64 " '%s' at line %" PRId64,
+             i,
+             l->symbol,
+             l->lineno);
       else
         msg (2, "state %" PRId64 " at line %" PRId64, i, l->lineno);
-      states.push_back(l);
+      states.push_back (l);
     }
     break;
 
@@ -285,7 +290,8 @@ parse_model_line (Btor2Line *l)
     case BTOR2_TAG_usubo:
     case BTOR2_TAG_write:
     default:
-      die ("parse error in '%s' at line %" PRId64 ": unsupported '%" PRId64 " %s%s'",
+      die ("parse error in '%s' at line %" PRId64 ": unsupported '%" PRId64
+           " %s%s'",
            model_path,
            l->lineno,
            l->id,
@@ -303,13 +309,13 @@ parse_model ()
   if (!btor2parser_read_lines (model, model_file))
     die ("parse error in '%s' at %s", model_path, btor2parser_error (model));
   num_format_lines = btor2parser_max_id (model);
-  inits.resize(num_format_lines, nullptr);
-  nexts.resize(num_format_lines, nullptr);
+  inits.resize (num_format_lines, nullptr);
+  nexts.resize (num_format_lines, nullptr);
   Btor2LineIterator it = btor2parser_iter_init (model);
   Btor2Line *line;
   while ((line = btor2parser_iter_next (&it))) parse_model_line (line);
 
-  for (size_t i = 0; i < states.size(); i++)
+  for (size_t i = 0; i < states.size (); i++)
   {
     Btor2Line *state = states[i];
     if (!nexts[state->id])
@@ -561,7 +567,7 @@ initialize_inputs (int64_t k, int32_t randomize)
 {
   msg (1, "initializing inputs @%" PRId64, k);
   if (print_trace) printf ("@%" PRId64 "\n", k);
-  for (size_t i = 0; i < inputs.size(); i++)
+  for (size_t i = 0; i < inputs.size (); i++)
   {
     Btor2Line *input = inputs[i];
     uint32_t width   = input->sort.bitvec.width;
@@ -587,7 +593,7 @@ initialize_states (int32_t randomly)
 {
   msg (1, "initializing states at #0");
   if (print_trace) printf ("#0\n");
-  for (size_t i = 0; i < states.size(); i++)
+  for (size_t i = 0; i < states.size (); i++)
   {
     Btor2Line *state = states[i];
     assert (0 <= state->id), assert (state->id < num_format_lines);
@@ -642,7 +648,7 @@ simulate_step (int64_t k, int32_t randomize_states_that_are_inputs)
 #endif
     btorsim_bv_free (bv);
   }
-  for (size_t i = 0; i < states.size(); i++)
+  for (size_t i = 0; i < states.size (); i++)
   {
     Btor2Line *state = states[i];
     assert (0 <= state->id), assert (state->id < num_format_lines);
@@ -669,13 +675,14 @@ simulate_step (int64_t k, int32_t randomize_states_that_are_inputs)
 
   if (constraints_violated < 0)
   {
-    for (size_t i = 0; i < constraints.size(); i++)
+    for (size_t i = 0; i < constraints.size (); i++)
     {
       Btor2Line *constraint = constraints[i];
       BtorSimBitVector *bv  = current_state[constraint->args[0]];
       if (!btorsim_bv_is_zero (bv)) continue;
       msg (1,
-           "constraint(%" PRId64 ") '%" PRId64 " constraint %" PRId64 "' violated at time %" PRId64,
+           "constraint(%" PRId64 ") '%" PRId64 " constraint %" PRId64
+           "' violated at time %" PRId64,
            i,
            constraint->id,
            constraint->args[0],
@@ -686,7 +693,7 @@ simulate_step (int64_t k, int32_t randomize_states_that_are_inputs)
 
   if (constraints_violated < 0)
   {
-    for (size_t i = 0; i < bads.size(); i++)
+    for (size_t i = 0; i < bads.size (); i++)
     {
       int64_t r = reached_bads[i];
       if (r >= 0) continue;
@@ -700,7 +707,7 @@ simulate_step (int64_t k, int32_t randomize_states_that_are_inputs)
       if (!--num_unreached_bads)
         msg (1,
              "all %" PRId64 " bad state properties reached",
-             (int64_t) bads.size());
+             (int64_t) bads.size ());
     }
   }
 }
@@ -711,7 +718,7 @@ transition (int64_t k)
   msg (1, "transition %" PRId64, k);
   for (int64_t i = 0; i < num_format_lines; i++) delete_current_state (i);
   if (print_trace && print_states) printf ("#%" PRId64 "\n", k);
-  for (size_t i = 0; i < states.size(); i++)
+  for (size_t i = 0; i < states.size (); i++)
   {
     Btor2Line *state = states[i];
     assert (0 <= state->id), assert (state->id < num_format_lines);
@@ -732,22 +739,22 @@ transition (int64_t k)
 static void
 report ()
 {
-  if (verbosity && num_unreached_bads < (int64_t) bads.size())
+  if (verbosity && num_unreached_bads < (int64_t) bads.size ())
   {
     printf ("[btorsim] reached bad state properties {");
-    for (size_t i = 0; i < bads.size(); i++)
+    for (size_t i = 0; i < bads.size (); i++)
     {
       int64_t r = reached_bads[i];
       if (r >= 0) printf (" b%lu@%" PRId64, i, r);
     }
     printf (" }\n");
   }
-  else if (!bads.empty())
+  else if (!bads.empty ())
     msg (1, "no bad state property reached");
 
   if (constraints_violated >= 0)
     msg (1, "constraints violated at time %" PRId64, constraints_violated);
-  else if (!constraints.empty())
+  else if (!constraints.empty ())
     msg (1, "constraints always satisfied");
 }
 
@@ -840,7 +847,8 @@ parse_error (const char *msg, ...)
   fflush (stdout);
   assert (witness_path);
   fprintf (stderr,
-           "*** 'btorsim' parse error in '%s' at line %" PRId64 " column %" PRId64 ": ",
+           "*** 'btorsim' parse error in '%s' at line %" PRId64
+           " column %" PRId64 ": ",
            witness_path,
            lineno,
            columno);
@@ -967,10 +975,10 @@ parse_state_part (int64_t k)
   while ((state_pos = parse_assignment ()) >= 0)
   {
     int64_t saved_charno = charno;
-    charno            = 1;
+    charno               = 1;
     assert (lineno > 1);
     lineno--;
-    if (state_pos >= (int64_t) states.size())
+    if (state_pos >= (int64_t) states.size ())
       parse_error ("less than %" PRId64 " states defined", state_pos);
     if (BTOR2_EMPTY_STACK (symbol))
       msg (4,
@@ -992,7 +1000,8 @@ parse_state_part (int64_t k)
       parse_error ("expected constant of width '%u'", state->sort.bitvec.width);
     assert (0 <= state->id), assert (state->id < num_format_lines);
     if (current_state[state->id] && nexts[state->id])
-      parse_error ("state %" PRId64 " id %" PRId64 " assigned twice in frame %" PRId64,
+      parse_error ("state %" PRId64 " id %" PRId64
+                   " assigned twice in frame %" PRId64,
                    state_pos,
                    state->id,
                    k);
@@ -1004,8 +1013,9 @@ parse_state_part (int64_t k)
       assert (init->args[0] == state->id);
       BtorSimBitVector *tmp = simulate (init->args[1]);
       if (btorsim_bv_compare (val, tmp))
-        parse_error (
-            "incompatible initialized state %" PRId64 " id %" PRId64, state_pos, state->id);
+        parse_error ("incompatible initialized state %" PRId64 " id %" PRId64,
+                     state_pos,
+                     state->id);
       btorsim_bv_free (tmp);
     }
     lineno++;
@@ -1034,10 +1044,10 @@ parse_input_part (int64_t k)
   while ((input_pos = parse_assignment ()) >= 0)
   {
     int64_t saved_charno = charno;
-    charno            = 1;
+    charno               = 1;
     assert (lineno > 1);
     lineno--;
-    if (input_pos >= (int64_t) inputs.size())
+    if (input_pos >= (int64_t) inputs.size ())
       parse_error ("less than %" PRId64 " defined", input_pos);
     if (BTOR2_EMPTY_STACK (symbol))
       msg (4,
@@ -1059,7 +1069,8 @@ parse_input_part (int64_t k)
       parse_error ("expected constant of width '%u'", input->sort.bitvec.width);
     assert (0 <= input->id), assert (input->id < num_format_lines);
     if (current_state[input->id])
-      parse_error ("input %" PRId64 " id %" PRId64 " assigned twice in frame %" PRId64,
+      parse_error ("input %" PRId64 " id %" PRId64
+                   " assigned twice in frame %" PRId64,
                    input_pos,
                    input->id,
                    k);
@@ -1113,12 +1124,13 @@ parse_sat_witness ()
     }
     if (type == 'b')
     {
-      if (bad >= (int64_t) bads.size())
+      if (bad >= (int64_t) bads.size ())
         parse_error ("invalid bad state property number %" PRId64, bad);
       msg (3,
-           "... claims to be witness of bad state property number 'b%" PRId64 "'",
+           "... claims to be witness of bad state property number 'b%" PRId64
+           "'",
            bad);
-      claimed_bad_witnesses.push_back(bad);
+      claimed_bad_witnesses.push_back (bad);
     }
     else
       parse_error ("can not handle justice properties yet");
@@ -1134,13 +1146,14 @@ parse_sat_witness ()
   report ();
   if (print_trace) printf (".\n"), fflush (stdout);
 
-  for (size_t i = 0; i < claimed_bad_witnesses.size(); i++)
+  for (size_t i = 0; i < claimed_bad_witnesses.size (); i++)
   {
     int64_t bad_pos = claimed_bad_witnesses[i];
     int64_t bound   = reached_bads[bad_pos];
-    Btor2Line *l = bads[bad_pos];
+    Btor2Line *l    = bads[bad_pos];
     if (bound < 0)
-      die ("claimed bad state property 'b%" PRId64 "' id %" PRId64 " not reached",
+      die ("claimed bad state property 'b%" PRId64 "' id %" PRId64
+           " not reached",
            bad_pos,
            l->id);
   }
@@ -1246,7 +1259,8 @@ parse_and_check_all_witnesses ()
   BTOR2_RELEASE_STACK (constant);
   BTOR2_RELEASE_STACK (symbol);
   msg (1,
-       "finished parsing %" PRId64 " witnesses after reading %" PRId64 " bytes (%.1f MB)",
+       "finished parsing %" PRId64 " witnesses after reading %" PRId64
+       " bytes (%.1f MB)",
        count_witnesses,
        charno,
        charno / (double) (1l << 20));
@@ -1342,14 +1356,14 @@ main (int32_t argc, char **argv)
   assert (model_path);
   msg (1, "reading BTOR model from '%s'", model_path);
   parse_model ();
-  if (fake_bad >= (int64_t) bads.size())
+  if (fake_bad >= (int64_t) bads.size ())
     die ("invalid faked bad state property number %" PRId64, fake_bad);
-  if (fake_justice >= (int64_t) justices.size())
+  if (fake_justice >= (int64_t) justices.size ())
     die ("invalid faked justice property number %" PRId64, fake_justice);
   if (close_model_file && fclose (model_file))
     die ("can not close model file '%s'", model_path);
-  current_state.resize(num_format_lines, nullptr);
-  next_state.resize(num_format_lines, nullptr);
+  current_state.resize (num_format_lines, nullptr);
+  next_state.resize (num_format_lines, nullptr);
   if (random_mode)
   {
     if (r < 0) r = 20;

--- a/src/btorsim/btorsimbv.c
+++ b/src/btorsim/btorsimbv.c
@@ -12,11 +12,12 @@
  */
 
 #include "btorsimbv.h"
-#include "util/btor2mem.h"
 
 #include <assert.h>
 #include <ctype.h>
 #include <limits.h>
+
+#include "util/btor2mem.h"
 
 #define BTOR2_MASK_REM_BITS(bv)                            \
   ((((BTORSIM_BV_TYPE) 1 << (BTORSIM_BV_TYPE_BW - 1)) - 1) \

--- a/src/btorsim/btorsimbv.h
+++ b/src/btorsim/btorsimbv.h
@@ -16,6 +16,11 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+
+#if __cplusplus
+extern "C" {
+#endif
+
 #include "btorsimrng.h"
 #include "util/btor2stack.h"
 
@@ -228,5 +233,9 @@ bool btorsim_bv_is_umulo (const BtorSimBitVector *bv0,
                           const BtorSimBitVector *bv1);
 
 /*------------------------------------------------------------------------*/
+
+#if __cplusplus
+}
+#endif
 
 #endif

--- a/src/btorsim/btorsimrng.h
+++ b/src/btorsim/btorsimrng.h
@@ -15,6 +15,10 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#if __cplusplus
+extern "C" {
+#endif
+
 struct BtorSimRNG
 {
   uint32_t z, w;
@@ -26,4 +30,7 @@ void btorsim_rng_init (BtorSimRNG* rng, uint32_t seed);
 uint32_t btorsim_rng_rand (BtorSimRNG* rng);
 uint32_t btorsim_rng_pick_rand (BtorSimRNG* rng, uint32_t from, uint32_t to);
 
+#if __cplusplus
+}
+#endif
 #endif


### PR DESCRIPTION
The first in a series of PRs trying to cut #4 into somewhat more manageable chunks.

This introduces changes to compile btorsim with g++, and updates some of the data structures to use `std::vector` instead of `btor2stack/btor2mem`. The parser, rng, and the `BtorSimBitVector` struct remain as C libraries. (The `BtorSimBitVector` implementation would not be valid C++.)