### PR TITLE
Add array support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,8 @@ add_library(btor2parser
 target_include_directories(btor2parser PRIVATE .)
 
 add_executable(btorsim
+  btorsim/btorsimam.cpp
+  btorsim/btorsimstate.cpp
   btorsim/btorsim.cpp
   btorsim/btorsimbv.c
   btorsim/btorsimrng.c

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,12 +4,13 @@ add_library(btor2parser
 target_include_directories(btor2parser PRIVATE .)
 
 add_executable(btorsim
-  btorsim/btorsim.c
+  btorsim/btorsim.cpp
   btorsim/btorsimbv.c
   btorsim/btorsimrng.c
 )
 target_include_directories(btorsim PRIVATE .)
 target_link_libraries(btorsim btor2parser)
+target_compile_options(btorsim PRIVATE -Wall)
 
 add_executable(catbtor catbtor.c)
 target_link_libraries(catbtor btor2parser)

--- a/src/btorsim/btorsim.cpp
+++ b/src/btorsim/btorsim.cpp
@@ -21,6 +21,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <string>
+
 #include "btor2parser/btor2parser.h"
 #include "btorsimbv.h"
 #include "btorsimrng.h"
@@ -30,7 +32,7 @@
 /*------------------------------------------------------------------------*/
 
 static void
-die (char *m, ...)
+die (const char* m, ...)
 {
   fflush (stdout);
   fputs ("*** 'btorsim' error: ", stderr);
@@ -46,7 +48,7 @@ static int32_t verbosity;
 static int32_t print_states;
 
 static void
-msg (int32_t level, char *m, ...)
+msg (int32_t level, const char* m, ...)
 {
   if (level > verbosity) return;
   assert (m);

--- a/src/btorsim/btorsim.cpp
+++ b/src/btorsim/btorsim.cpp
@@ -1168,23 +1168,14 @@ static void
 parse_state_part (int64_t k)
 {
   int32_t ch = next_char ();
-  if (k == 0)
+  if (ch != '#')
   {
-    if (ch != '#' || parse_unsigned_number (&ch) != k || ch != '\n')
-      parse_error (
-          "missing '#%" PRId64 "' state part header of frame %" PRId64, k, k);
+    prev_char (ch);
+    return;
   }
-  else
-  {
-    if (ch != '#')
-    {
-      prev_char (ch);
-      return;
-    }
-    if (parse_unsigned_number (&ch) != k || ch != '\n')
-      parse_error (
-          "missing '#%" PRId64 "' state part header of frame %" PRId64, k, k);
-  }
+  if (parse_unsigned_number (&ch) != k || ch != '\n')
+    parse_error (
+        "missing '#%" PRId64 "' state part header of frame %" PRId64, k, k);
   int64_t state_pos;
   while ((state_pos = parse_assignment ()) >= 0)
   {
@@ -1473,7 +1464,7 @@ parse_sat_witness ()
   int64_t k = 0;
   while (parse_frame (k)) k++;
 
-  if (!found_initial_frame) parse_error ("initial frame missing");
+  if (!found_initial_frame && states.size() > 0) parse_error ("initial frame missing");
   msg (1, "finished parsing k = %" PRId64 " frames", k);
 
   report ();
@@ -1499,7 +1490,7 @@ parse_unknown_witness ()
 
   while (parse_frame (k)) k++;
 
-  if (!found_initial_frame) parse_error ("initial frame missing");
+  if (!found_initial_frame && states.size() > 0) parse_error ("initial frame missing");
 
   report ();
   if (print_trace) printf (".\n"), fflush (stdout);

--- a/src/btorsim/btorsim.cpp
+++ b/src/btorsim/btorsim.cpp
@@ -354,6 +354,29 @@ delete_current_state (int64_t id)
   if (current_state[id].type) current_state[id].remove();
 }
 
+static Btor2Sort *get_sort(Btor2Line* l)
+{
+  Btor2Sort *sort;
+  switch (l->tag) {
+    case BTOR2_TAG_output:
+    case BTOR2_TAG_bad:
+    case BTOR2_TAG_constraint:
+    case BTOR2_TAG_fair:
+    // case BTOR2_TAG_justice:
+      {
+        Btor2Line *ls = btor2parser_get_line_by_id (model, l->args[0]);
+        sort = &(ls->sort);
+      }
+      break;
+    default:
+      sort = &(l->sort);
+      break;
+  }
+  assert(sort);
+  assert(sort->id);
+  return sort;
+}
+
 static BtorSimState
 simulate (int64_t id)
 {
@@ -1600,7 +1623,8 @@ void setup_states ()
     Btor2Line *l = btor2parser_get_line_by_id (model, i);
     if (l)
     {
-      switch (l->sort.tag) {
+      Btor2Sort *sort = get_sort(l);
+      switch (sort->tag) {
         case BTOR2_TAG_SORT_bitvec:
           current_state[i].type = BITVEC;
           next_state[i].type = BITVEC;

--- a/src/btorsim/btorsim.cpp
+++ b/src/btorsim/btorsim.cpp
@@ -22,12 +22,11 @@
 #include <string.h>
 
 #include <string>
+#include <vector>
 
 #include "btor2parser/btor2parser.h"
 #include "btorsimbv.h"
 #include "btorsimrng.h"
-#include "util/btor2mem.h"
-#include "util/btor2stack.h"
 
 /*------------------------------------------------------------------------*/
 
@@ -138,27 +137,23 @@ static int32_t random_mode   = 0;
 
 static Btor2Parser *model;
 
-BTOR2_DECLARE_STACK (Btor2LinePtr, Btor2Line *);
+static std::vector<Btor2Line *> inputs;
+static std::vector<Btor2Line *> states;
+static std::vector<Btor2Line *> bads;
+static std::vector<Btor2Line *> constraints;
+static std::vector<Btor2Line *> justices;
 
-static Btor2LinePtrStack inputs;
-static Btor2LinePtrStack states;
-static Btor2LinePtrStack bads;
-static Btor2LinePtrStack constraints;
-static Btor2LinePtrStack justices;
-
-BTOR2_DECLARE_STACK (BtorLong, int64_t);
-
-static BtorLongStack reached_bads;
+static std::vector<int64_t> reached_bads;
 
 static int64_t constraints_violated = -1;
 static int64_t num_unreached_bads;
 
 static int64_t num_format_lines;
-static Btor2Line **inits;
-static Btor2Line **nexts;
+static std::vector<Btor2Line *> inits;
+static std::vector<Btor2Line *> nexts;
 
-static BtorSimBitVector **current_state;
-static BtorSimBitVector **next_state;
+static std::vector<BtorSimBitVector *> current_state;
+static std::vector<BtorSimBitVector *> next_state;
 
 static void
 parse_model_line (Btor2Line *l)
@@ -167,19 +162,19 @@ parse_model_line (Btor2Line *l)
   {
     case BTOR2_TAG_bad:
     {
-      int64_t i = (int64_t) BTOR2_COUNT_STACK (bads);
+      int64_t i = (int64_t) bads.size();
       msg (2, "bad %" PRId64 " at line %" PRId64, i, l->lineno);
-      BTOR2_PUSH_STACK (bads, l);
-      BTOR2_PUSH_STACK (reached_bads, -1);
+      bads.push_back(l);
+      reached_bads.push_back(-1);
       num_unreached_bads++;
     }
     break;
 
     case BTOR2_TAG_constraint:
     {
-      int64_t i = (int64_t) BTOR2_COUNT_STACK (constraints);
+      int64_t i = (int64_t) constraints.size();
       msg (2, "constraint %" PRId64 " at line %" PRId64, i, l->lineno);
-      BTOR2_PUSH_STACK (constraints, l);
+      constraints.push_back(l);
     }
     break;
 
@@ -187,12 +182,12 @@ parse_model_line (Btor2Line *l)
 
     case BTOR2_TAG_input:
     {
-      int64_t i = (int64_t) BTOR2_COUNT_STACK (inputs);
+      int64_t i = (int64_t) inputs.size();
       if (l->symbol)
         msg (2, "input %" PRId64 " '%s' at line %" PRId64, i, l->symbol, l->lineno);
       else
         msg (2, "input %" PRId64 " at line %" PRId64, i, l->lineno);
-      BTOR2_PUSH_STACK (inputs, l);
+      inputs.push_back(l);
     }
     break;
 
@@ -219,12 +214,12 @@ parse_model_line (Btor2Line *l)
 
     case BTOR2_TAG_state:
     {
-      int64_t i = (int64_t) BTOR2_COUNT_STACK (states);
+      int64_t i = (int64_t) states.size();
       if (l->symbol)
         msg (2, "state %" PRId64 " '%s' at line %" PRId64, i, l->symbol, l->lineno);
       else
         msg (2, "state %" PRId64 " at line %" PRId64, i, l->lineno);
-      BTOR2_PUSH_STACK (states, l);
+      states.push_back(l);
     }
     break;
 
@@ -303,26 +298,20 @@ parse_model_line (Btor2Line *l)
 static void
 parse_model ()
 {
-  BTOR2_INIT_STACK (inputs);
-  BTOR2_INIT_STACK (states);
-  BTOR2_INIT_STACK (bads);
-  BTOR2_INIT_STACK (justices);
-  BTOR2_INIT_STACK (reached_bads);
-  BTOR2_INIT_STACK (constraints);
   assert (model_file);
   model = btor2parser_new ();
   if (!btor2parser_read_lines (model, model_file))
     die ("parse error in '%s' at %s", model_path, btor2parser_error (model));
   num_format_lines = btor2parser_max_id (model);
-  BTOR2_CNEWN (inits, num_format_lines);
-  BTOR2_CNEWN (nexts, num_format_lines);
+  inits.resize(num_format_lines, nullptr);
+  nexts.resize(num_format_lines, nullptr);
   Btor2LineIterator it = btor2parser_iter_init (model);
   Btor2Line *line;
   while ((line = btor2parser_iter_next (&it))) parse_model_line (line);
 
-  for (int64_t i = 0; i < BTOR2_COUNT_STACK (states); i++)
+  for (size_t i = 0; i < states.size(); i++)
   {
-    Btor2Line *state = BTOR2_PEEK_STACK (states, i);
+    Btor2Line *state = states[i];
     if (!nexts[state->id])
     {
       msg (1, "state %d without next function", state->id);
@@ -572,9 +561,9 @@ initialize_inputs (int64_t k, int32_t randomize)
 {
   msg (1, "initializing inputs @%" PRId64, k);
   if (print_trace) printf ("@%" PRId64 "\n", k);
-  for (int64_t i = 0; i < BTOR2_COUNT_STACK (inputs); i++)
+  for (size_t i = 0; i < inputs.size(); i++)
   {
-    Btor2Line *input = BTOR2_PEEK_STACK (inputs, i);
+    Btor2Line *input = inputs[i];
     uint32_t width   = input->sort.bitvec.width;
     if (current_state[input->id]) continue;
     BtorSimBitVector *update;
@@ -585,7 +574,7 @@ initialize_inputs (int64_t k, int32_t randomize)
     update_current_state (input->id, update);
     if (print_trace)
     {
-      printf ("%" PRId64 " ", i);
+      printf ("%lu ", i);
       btorsim_bv_print_without_new_line (update);
       if (input->symbol) printf (" %s@%" PRId64, input->symbol, k);
       fputc ('\n', stdout);
@@ -598,9 +587,9 @@ initialize_states (int32_t randomly)
 {
   msg (1, "initializing states at #0");
   if (print_trace) printf ("#0\n");
-  for (int64_t i = 0; i < BTOR2_COUNT_STACK (states); i++)
+  for (size_t i = 0; i < states.size(); i++)
   {
-    Btor2Line *state = BTOR2_PEEK_STACK (states, i);
+    Btor2Line *state = states[i];
     assert (0 <= state->id), assert (state->id < num_format_lines);
     if (current_state[state->id]) continue;
     Btor2Line *init = inits[state->id];
@@ -623,7 +612,7 @@ initialize_states (int32_t randomly)
     update_current_state (state->id, update);
     if (print_trace && !init)
     {
-      printf ("%" PRId64 " ", i);
+      printf ("%lu ", i);
       btorsim_bv_print_without_new_line (update);
       if (state->symbol) printf (" %s#0", state->symbol);
       fputc ('\n', stdout);
@@ -653,9 +642,9 @@ simulate_step (int64_t k, int32_t randomize_states_that_are_inputs)
 #endif
     btorsim_bv_free (bv);
   }
-  for (int64_t i = 0; i < BTOR2_COUNT_STACK (states); i++)
+  for (size_t i = 0; i < states.size(); i++)
   {
-    Btor2Line *state = BTOR2_PEEK_STACK (states, i);
+    Btor2Line *state = states[i];
     assert (0 <= state->id), assert (state->id < num_format_lines);
     Btor2Line *next = nexts[state->id];
     BtorSimBitVector *update;
@@ -680,9 +669,9 @@ simulate_step (int64_t k, int32_t randomize_states_that_are_inputs)
 
   if (constraints_violated < 0)
   {
-    for (int64_t i = 0; i < BTOR2_COUNT_STACK (constraints); i++)
+    for (size_t i = 0; i < constraints.size(); i++)
     {
-      Btor2Line *constraint = BTOR2_PEEK_STACK (constraints, i);
+      Btor2Line *constraint = constraints[i];
       BtorSimBitVector *bv  = current_state[constraint->args[0]];
       if (!btorsim_bv_is_zero (bv)) continue;
       msg (1,
@@ -697,21 +686,21 @@ simulate_step (int64_t k, int32_t randomize_states_that_are_inputs)
 
   if (constraints_violated < 0)
   {
-    for (int64_t i = 0; i < BTOR2_COUNT_STACK (bads); i++)
+    for (size_t i = 0; i < bads.size(); i++)
     {
-      int64_t r = BTOR2_PEEK_STACK (reached_bads, i);
+      int64_t r = reached_bads[i];
       if (r >= 0) continue;
-      Btor2Line *bad       = BTOR2_PEEK_STACK (bads, i);
+      Btor2Line *bad       = bads[i];
       BtorSimBitVector *bv = current_state[bad->args[0]];
       if (btorsim_bv_is_zero (bv)) continue;
-      int64_t bound = BTOR2_PEEK_STACK (reached_bads, i);
+      int64_t bound = reached_bads[i];
       if (bound >= 0) continue;
-      BTOR2_POKE_STACK (reached_bads, i, k);
+      reached_bads[i] = k;
       assert (num_unreached_bads > 0);
       if (!--num_unreached_bads)
         msg (1,
              "all %" PRId64 " bad state properties reached",
-             (int64_t) BTOR2_COUNT_STACK (bads));
+             (int64_t) bads.size());
     }
   }
 }
@@ -722,9 +711,9 @@ transition (int64_t k)
   msg (1, "transition %" PRId64, k);
   for (int64_t i = 0; i < num_format_lines; i++) delete_current_state (i);
   if (print_trace && print_states) printf ("#%" PRId64 "\n", k);
-  for (int64_t i = 0; i < BTOR2_COUNT_STACK (states); i++)
+  for (size_t i = 0; i < states.size(); i++)
   {
-    Btor2Line *state = BTOR2_PEEK_STACK (states, i);
+    Btor2Line *state = states[i];
     assert (0 <= state->id), assert (state->id < num_format_lines);
     BtorSimBitVector *update = next_state[state->id];
     assert (update);
@@ -732,7 +721,7 @@ transition (int64_t k)
     next_state[state->id] = 0;
     if (print_trace && print_states)
     {
-      printf ("%" PRId64 " ", i);
+      printf ("%lu ", i);
       btorsim_bv_print_without_new_line (update);
       if (state->symbol) printf (" %s#%" PRId64, state->symbol, k);
       fputc ('\n', stdout);
@@ -743,22 +732,22 @@ transition (int64_t k)
 static void
 report ()
 {
-  if (verbosity && num_unreached_bads < BTOR2_COUNT_STACK (bads))
+  if (verbosity && num_unreached_bads < (int64_t) bads.size())
   {
     printf ("[btorsim] reached bad state properties {");
-    for (int64_t i = 0; i < BTOR2_COUNT_STACK (bads); i++)
+    for (size_t i = 0; i < bads.size(); i++)
     {
-      int64_t r = BTOR2_PEEK_STACK (reached_bads, i);
-      if (r >= 0) printf (" b%" PRId64 "@%" PRId64, i, r);
+      int64_t r = reached_bads[i];
+      if (r >= 0) printf (" b%lu@%" PRId64, i, r);
     }
     printf (" }\n");
   }
-  else if (!BTOR2_EMPTY_STACK (bads))
+  else if (!bads.empty())
     msg (1, "no bad state property reached");
 
   if (constraints_violated >= 0)
     msg (1, "constraints violated at time %" PRId64, constraints_violated);
-  else if (!BTOR2_EMPTY_STACK (constraints))
+  else if (!constraints.empty())
     msg (1, "constraints always satisfied");
 }
 
@@ -868,8 +857,8 @@ static int64_t count_unsat_witnesses;
 static int64_t count_unknown_witnesses;
 static int64_t count_witnesses;
 
-static BtorLongStack claimed_bad_witnesses;
-static BtorLongStack claimed_justice_witnesses;
+static std::vector<int64_t> claimed_bad_witnesses;
+static std::vector<int64_t> claimed_justice_witnesses;
 
 static int64_t
 parse_unsigned_number (int32_t *ch_ptr)
@@ -981,7 +970,7 @@ parse_state_part (int64_t k)
     charno            = 1;
     assert (lineno > 1);
     lineno--;
-    if (state_pos >= BTOR2_COUNT_STACK (states))
+    if (state_pos >= (int64_t) states.size())
       parse_error ("less than %" PRId64 " states defined", state_pos);
     if (BTOR2_EMPTY_STACK (symbol))
       msg (4,
@@ -996,7 +985,7 @@ parse_state_part (int64_t k)
            constant.start,
            symbol.start,
            k);
-    Btor2Line *state = BTOR2_PEEK_STACK (states, state_pos);
+    Btor2Line *state = states[state_pos];
     assert (state);
     if (strlen (constant.start) != state->sort.bitvec.width)
       charno = constant_columno,
@@ -1048,7 +1037,7 @@ parse_input_part (int64_t k)
     charno            = 1;
     assert (lineno > 1);
     lineno--;
-    if (input_pos >= BTOR2_COUNT_STACK (inputs))
+    if (input_pos >= (int64_t) inputs.size())
       parse_error ("less than %" PRId64 " defined", input_pos);
     if (BTOR2_EMPTY_STACK (symbol))
       msg (4,
@@ -1063,7 +1052,7 @@ parse_input_part (int64_t k)
            constant.start,
            symbol.start,
            k);
-    Btor2Line *input = BTOR2_PEEK_STACK (inputs, input_pos);
+    Btor2Line *input = inputs[input_pos];
     assert (input);
     if (strlen (constant.start) != input->sort.bitvec.width)
       charno = constant_columno,
@@ -1102,9 +1091,6 @@ parse_sat_witness ()
 
   msg (1, "parsing 'sat' witness %" PRId64, count_sat_witnesses);
 
-  BTOR2_INIT_STACK (claimed_bad_witnesses);
-  BTOR2_INIT_STACK (claimed_justice_witnesses);
-
   for (;;)
   {
     int32_t type = next_char ();
@@ -1127,12 +1113,12 @@ parse_sat_witness ()
     }
     if (type == 'b')
     {
-      if (bad >= BTOR2_COUNT_STACK (bads))
+      if (bad >= (int64_t) bads.size())
         parse_error ("invalid bad state property number %" PRId64, bad);
       msg (3,
            "... claims to be witness of bad state property number 'b%" PRId64 "'",
            bad);
-      BTOR2_PUSH_STACK (claimed_bad_witnesses, bad);
+      claimed_bad_witnesses.push_back(bad);
     }
     else
       parse_error ("can not handle justice properties yet");
@@ -1148,19 +1134,16 @@ parse_sat_witness ()
   report ();
   if (print_trace) printf (".\n"), fflush (stdout);
 
-  for (int64_t i = 0; i < BTOR2_COUNT_STACK (claimed_bad_witnesses); i++)
+  for (size_t i = 0; i < claimed_bad_witnesses.size(); i++)
   {
-    int64_t bad_pos = BTOR2_PEEK_STACK (claimed_bad_witnesses, i);
-    int64_t bound   = BTOR2_PEEK_STACK (reached_bads, bad_pos);
-    Btor2Line *l = BTOR2_PEEK_STACK (bads, bad_pos);
+    int64_t bad_pos = claimed_bad_witnesses[i];
+    int64_t bound   = reached_bads[bad_pos];
+    Btor2Line *l = bads[bad_pos];
     if (bound < 0)
       die ("claimed bad state property 'b%" PRId64 "' id %" PRId64 " not reached",
            bad_pos,
            l->id);
   }
-
-  BTOR2_RELEASE_STACK (claimed_bad_witnesses);
-  BTOR2_RELEASE_STACK (claimed_justice_witnesses);
 }
 
 static void
@@ -1359,14 +1342,14 @@ main (int32_t argc, char **argv)
   assert (model_path);
   msg (1, "reading BTOR model from '%s'", model_path);
   parse_model ();
-  if (fake_bad >= BTOR2_COUNT_STACK (bads))
+  if (fake_bad >= (int64_t) bads.size())
     die ("invalid faked bad state property number %" PRId64, fake_bad);
-  if (fake_justice >= BTOR2_COUNT_STACK (justices))
+  if (fake_justice >= (int64_t) justices.size())
     die ("invalid faked justice property number %" PRId64, fake_justice);
   if (close_model_file && fclose (model_file))
     die ("can not close model file '%s'", model_path);
-  BTOR2_CNEWN (current_state, num_format_lines);
-  BTOR2_CNEWN (next_state, num_format_lines);
+  current_state.resize(num_format_lines, nullptr);
+  next_state.resize(num_format_lines, nullptr);
   if (random_mode)
   {
     if (r < 0) r = 20;
@@ -1392,20 +1375,10 @@ main (int32_t argc, char **argv)
     if (close_witness_file && fclose (witness_file))
       die ("can not close witness file '%s'", witness_path);
   }
-  BTOR2_RELEASE_STACK (inputs);
-  BTOR2_RELEASE_STACK (states);
-  BTOR2_RELEASE_STACK (bads);
-  BTOR2_RELEASE_STACK (justices);
-  BTOR2_RELEASE_STACK (reached_bads);
-  BTOR2_RELEASE_STACK (constraints);
   btor2parser_delete (model);
-  BTOR2_DELETE (inits);
-  BTOR2_DELETE (nexts);
   for (int64_t i = 0; i < num_format_lines; i++)
     if (current_state[i]) btorsim_bv_free (current_state[i]);
   for (int64_t i = 0; i < num_format_lines; i++)
     if (next_state[i]) btorsim_bv_free (next_state[i]);
-  BTOR2_DELETE (current_state);
-  BTOR2_DELETE (next_state);
   return 0;
 }

--- a/src/btorsim/btorsimam.cpp
+++ b/src/btorsim/btorsimam.cpp
@@ -1,0 +1,92 @@
+#include <cassert>
+#include "btorsimam.h"
+
+
+
+BtorSimBitVector* BtorSimArrayModel::read(const BtorSimBitVector* index)
+{
+	uint64_t i = btorsim_bv_to_uint64(index);
+	assert(i < depth);
+	//TODO: uninitialized data is assumed to be zero? what about random mode?
+	BtorSimBitVector* element = data[i];
+	return btorsim_bv_copy(element);
+}
+
+BtorSimArrayModel* BtorSimArrayModel::write(const BtorSimBitVector* index, const BtorSimBitVector* element)
+{
+	uint64_t i = btorsim_bv_to_uint64(index);
+	assert(i < depth);
+	assert(element->width == width);
+	BtorSimArrayModel* res = copy();
+	res->data[i] = btorsim_bv_copy(element);
+	return res;
+}
+
+BtorSimArrayModel* BtorSimArrayModel::copy() const
+{
+	BtorSimArrayModel* res = new BtorSimArrayModel(width, depth);
+	for (auto i: data)
+		res->data[i.first] = btorsim_bv_copy(i.second);
+	return res;
+}
+
+bool BtorSimArrayModel::operator==(const BtorSimArrayModel& other) const
+{
+	for (auto i: data)
+		if (other.data.find(i.first)==other.data.end() || btorsim_bv_compare(other.data.at(i.first), i.second) != 0)
+		{
+			return false;
+		}
+	return true;
+}
+
+bool BtorSimArrayModel::operator!=(const BtorSimArrayModel& other) const
+{
+	return !operator==(other);
+}
+
+
+
+BtorSimBitVector* btorsim_am_eq(const BtorSimArrayModel* a, const BtorSimArrayModel* b)
+{
+	//TODO: is comparing arrays of different dimensions false or error?
+	assert (a), assert (b);
+	assert (a->width == b->width);
+	assert (a->depth == b->depth);
+	uint32_t bit = (*a == *b) ? 1 : 0;
+
+	BtorSimBitVector* res = btorsim_bv_new(1);
+	btorsim_bv_set_bit (res, 0, bit);
+	return res;
+}
+
+BtorSimBitVector* btorsim_am_neq(const BtorSimArrayModel* a, const BtorSimArrayModel* b)
+{
+	//TODO: is comparing arrays of different dimensions false or error?
+	assert(a), assert(b);
+	assert (a->width == b->width);
+	assert (a->depth == b->depth);
+	uint32_t bit = (*a == *b) ? 0 : 1;
+
+	BtorSimBitVector* res = btorsim_bv_new(1);
+	btorsim_bv_set_bit (res, 0, bit);
+	return res;
+}
+
+BtorSimArrayModel* btorsim_am_ite(const BtorSimBitVector* c, const BtorSimArrayModel* t, const BtorSimArrayModel* e)
+{
+	assert (c);
+	assert (c->len == 1);
+	assert(t);
+	assert(e);
+	assert(t->width == e->width);
+	assert(t->depth == e->depth);
+
+	BtorSimArrayModel* res;
+	if(btorsim_bv_get_bit (c, 0))
+		res = t->copy();
+	else
+		res = e->copy();
+
+	return res;
+}

--- a/src/btorsim/btorsimam.cpp
+++ b/src/btorsim/btorsimam.cpp
@@ -10,12 +10,23 @@ BtorSimArrayModel::~BtorSimArrayModel()
 	}
 }
 
+uint64_t BtorSimArrayModel::get_random_init(uint64_t idx) const
+{
+	return (random_seed + idx)*(random_seed + idx + 1)/2 + idx;
+}
+
 BtorSimBitVector* BtorSimArrayModel::read(const BtorSimBitVector* index)
 {
 	uint64_t i = btorsim_bv_to_uint64(index);
 	assert(i < depth);
 	//TODO: uninitialized data is assumed to be zero? what about random mode?
-	if (!data[i]) data[i] = btorsim_bv_new(width);
+	if (!data[i])
+	{
+		if (random_seed)
+			data[i] = btorsim_bv_uint64_to_bv (get_random_init(i), width);
+		else
+			data[i] = btorsim_bv_new(width);
+	}
 	return btorsim_bv_copy(data[i]);
 }
 

--- a/src/btorsim/btorsimam.h
+++ b/src/btorsim/btorsimam.h
@@ -22,14 +22,17 @@
 struct BtorSimArrayModel {
 	uint64_t width;
 	uint64_t depth;
+	uint64_t random_seed;
 
 	std::map<uint64_t, BtorSimBitVector*> data;
 
-	BtorSimArrayModel(uint64_t width, uint64_t depth) : width(width), depth(depth) {};
+	BtorSimArrayModel(uint64_t width, uint64_t depth) : width(width), depth(depth), random_seed(0) {};
+	BtorSimArrayModel(uint64_t width, uint64_t depth, uint64_t random_seed) : width(width), depth(depth), random_seed(random_seed) {};
 	~BtorSimArrayModel();
 	BtorSimArrayModel(const BtorSimArrayModel&) = delete;
 	BtorSimArrayModel& operator=(const BtorSimArrayModel&) = delete;
 
+	uint64_t get_random_init(uint64_t idx) const;
 	BtorSimBitVector* read(const BtorSimBitVector* index);
 	BtorSimArrayModel* write(const BtorSimBitVector* index, const BtorSimBitVector* element);
 	BtorSimBitVector* check(const BtorSimBitVector* index) const;

--- a/src/btorsim/btorsimam.h
+++ b/src/btorsim/btorsimam.h
@@ -1,0 +1,43 @@
+/**
+ *  Btor2Tools: A tool package for the BTOR format.
+ *
+ *  Copyright (c) 2013-2016 Mathias Preiner.
+ *  Copyright (c) 2015-2018 Aina Niemetz.
+ *  Copyright (c) 2018 Armin Biere.
+ *  Copyright (c) 2020 Nina Engelhardt.
+ *
+ *  All rights reserved.
+ *
+ *  This file is part of the Btor2Tools package.
+ *  See LICENSE.txt for more information on using this software.
+ */
+
+#ifndef BTOR2AM_H_INCLUDED
+#define BTOR2AM_H_INCLUDED
+
+#include <map>
+
+#include "btorsimbv.h"
+
+struct BtorSimArrayModel {
+	uint64_t width;
+	uint64_t depth;
+
+	std::map<uint64_t, BtorSimBitVector*> data;
+
+	BtorSimArrayModel(uint64_t width, uint64_t depth) : width(width), depth(depth) {};
+	BtorSimArrayModel(const BtorSimArrayModel&) = delete;
+	BtorSimArrayModel& operator=(const BtorSimArrayModel&) = delete;
+
+	BtorSimBitVector* read(const BtorSimBitVector* index);
+	BtorSimArrayModel* write(const BtorSimBitVector* index, const BtorSimBitVector* element);
+	BtorSimArrayModel* copy() const;
+	bool operator!=(const BtorSimArrayModel& other) const;
+	bool operator==(const BtorSimArrayModel& other) const;
+};
+
+BtorSimBitVector* btorsim_am_eq(const BtorSimArrayModel* a, const BtorSimArrayModel* b);
+BtorSimBitVector* btorsim_am_neq(const BtorSimArrayModel* a, const BtorSimArrayModel* b);
+BtorSimArrayModel* btorsim_am_ite(const BtorSimBitVector* cond, const BtorSimArrayModel* a, const BtorSimArrayModel* b);
+
+#endif

--- a/src/btorsim/btorsimam.h
+++ b/src/btorsim/btorsimam.h
@@ -26,11 +26,13 @@ struct BtorSimArrayModel {
 	std::map<uint64_t, BtorSimBitVector*> data;
 
 	BtorSimArrayModel(uint64_t width, uint64_t depth) : width(width), depth(depth) {};
+	~BtorSimArrayModel();
 	BtorSimArrayModel(const BtorSimArrayModel&) = delete;
 	BtorSimArrayModel& operator=(const BtorSimArrayModel&) = delete;
 
 	BtorSimBitVector* read(const BtorSimBitVector* index);
 	BtorSimArrayModel* write(const BtorSimBitVector* index, const BtorSimBitVector* element);
+	BtorSimBitVector* check(const BtorSimBitVector* index) const;
 	BtorSimArrayModel* copy() const;
 	bool operator!=(const BtorSimArrayModel& other) const;
 	bool operator==(const BtorSimArrayModel& other) const;

--- a/src/btorsim/btorsimbv.h
+++ b/src/btorsim/btorsimbv.h
@@ -16,6 +16,11 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+
+#if __cplusplus
+extern "C" {
+#endif
+
 #include "btorsimrng.h"
 #include "util/btor2stack.h"
 
@@ -228,5 +233,9 @@ bool btorsim_bv_is_umulo (const BtorSimBitVector *bv0,
                           const BtorSimBitVector *bv1);
 
 /*------------------------------------------------------------------------*/
+
+#if __cplusplus
+}
+#endif
 
 #endif

--- a/src/btorsim/btorsimrng.h
+++ b/src/btorsim/btorsimrng.h
@@ -15,6 +15,10 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#if __cplusplus
+extern "C" {
+#endif
+
 struct BtorSimRNG
 {
   uint32_t z, w;
@@ -26,4 +30,7 @@ void btorsim_rng_init (BtorSimRNG* rng, uint32_t seed);
 uint32_t btorsim_rng_rand (BtorSimRNG* rng);
 uint32_t btorsim_rng_pick_rand (BtorSimRNG* rng, uint32_t from, uint32_t to);
 
+#if __cplusplus
+}
+#endif
 #endif

--- a/src/btorsim/btorsimstate.cpp
+++ b/src/btorsim/btorsimstate.cpp
@@ -10,7 +10,7 @@ void BtorSimState::update(BtorSimBitVector *bv)
 
 void BtorSimState::update(BtorSimArrayModel *am)
 {
-	assert(type == BtorSimStateType::ARRAY);
+	assert(type == ARRAY);
 	if (array_state) delete array_state;
 	array_state = am;
 }
@@ -19,10 +19,10 @@ void BtorSimState::update(BtorSimState& s)
 {
 	switch (type)
 	{
-	case BtorSimStateType::ARRAY:
+	case ARRAY:
 		update(s.array_state);
 		break;
-	case BtorSimStateType::BITVEC:
+	case BITVEC:
 		update(s.bv_state);
 		break;
 	default:
@@ -35,11 +35,11 @@ void BtorSimState::remove()
 {
 	switch (type)
 	{
-	case BtorSimStateType::ARRAY:
+	case ARRAY:
 		if (array_state) delete array_state;
 		array_state = nullptr;
 		break;
-	case BtorSimStateType::BITVEC:
+	case BITVEC:
 		if (bv_state) btorsim_bv_free(bv_state);
 		bv_state = nullptr;
 		break;
@@ -53,10 +53,10 @@ bool BtorSimState::is_set()
 {
 	switch (type)
 	{
-	case BtorSimStateType::ARRAY:
+	case ARRAY:
 		return array_state != nullptr;
-	case BtorSimStateType::BITVEC:
-		return bv_state != nullptr;\
+	case BITVEC:
+		return bv_state != nullptr;
 	default:
 		fprintf (stderr, "*** 'btorsim' error: Checking invalid state!\n");
 		exit (1);

--- a/src/btorsim/btorsimstate.cpp
+++ b/src/btorsim/btorsimstate.cpp
@@ -1,0 +1,64 @@
+#include <assert.h>
+#include "btorsimstate.h"
+
+void BtorSimState::update(BtorSimBitVector *bv)
+{
+	assert(type == BtorSimStateType::BITVEC);
+	if (bv_state) btorsim_bv_free(bv_state);
+	bv_state = bv;
+}
+
+void BtorSimState::update(BtorSimArrayModel *am)
+{
+	assert(type == BtorSimStateType::ARRAY);
+	if (array_state) delete array_state;
+	array_state = am;
+}
+
+void BtorSimState::update(BtorSimState& s)
+{
+	switch (type)
+	{
+	case BtorSimStateType::ARRAY:
+		update(s.array_state);
+		break;
+	case BtorSimStateType::BITVEC:
+		update(s.bv_state);
+		break;
+	default:
+		fprintf (stderr, "*** 'btorsim' error: Updating invalid state!\n");
+		exit (1);
+	}
+}
+
+void BtorSimState::remove()
+{
+	switch (type)
+	{
+	case BtorSimStateType::ARRAY:
+		if (array_state) delete array_state;
+		array_state = nullptr;
+		break;
+	case BtorSimStateType::BITVEC:
+		if (bv_state) btorsim_bv_free(bv_state);
+		bv_state = nullptr;
+		break;
+	default:
+		fprintf (stderr, "*** 'btorsim' error: Removing invalid state!\n");
+		exit (1);
+	}
+}
+
+bool BtorSimState::is_set()
+{
+	switch (type)
+	{
+	case BtorSimStateType::ARRAY:
+		return array_state != nullptr;
+	case BtorSimStateType::BITVEC:
+		return bv_state != nullptr;\
+	default:
+		fprintf (stderr, "*** 'btorsim' error: Checking invalid state!\n");
+		exit (1);
+	}
+}

--- a/src/btorsim/btorsimstate.h
+++ b/src/btorsim/btorsimstate.h
@@ -1,0 +1,19 @@
+#include "btorsimbv.h"
+#include "btorsimam.h"
+
+enum BtorSimStateType {INVALID, BITVEC, ARRAY};
+
+struct BtorSimState {
+	BtorSimStateType type;
+	union {
+		BtorSimBitVector *bv_state;
+		BtorSimArrayModel *array_state;
+	};
+
+	BtorSimState(): type(INVALID), bv_state(nullptr) {};
+	void update(BtorSimBitVector *bv);
+	void update(BtorSimArrayModel *bv);
+	void update(BtorSimState& s);
+	void remove();
+	bool is_set();
+};


### PR DESCRIPTION
The second in a series of PRs trying to cut #4 into somewhat more manageable chunks. You can view only the changes introduced in this PR [here](https://github.com/nakengelhardt/btor2tools/compare/move_to_cpp...nakengelhardt:add_arrays).

This introduces the classes `BtorSimArrayModel` (containing array information) and `BtorSimState` (typed container class for either bit vector or array model).

Some fixes/improvements in arrays were too tangled with the addition of VCD export to be practical to backport into this PR, and will follow in a fourth PR.

Edit: now live in PR #9. Please look at both together since it includes requested changes from #4.