### PR TITLE
Add cstdint include, which is needed by some compilers

### DIFF
--- a/src/btorsplit.cpp
+++ b/src/btorsplit.cpp
@@ -12,6 +12,7 @@
 #include <sys/stat.h>
 #include <algorithm>
 #include <cstdarg>
+#include <cstdint>
 #include <cstring>
 #include <fstream>
 #include <iomanip>


### PR DESCRIPTION
It seems like ```#include <cstdint>``` is needed by some compilers.

g++ version 13.2.0 gives the following error when it's omitted:
```
btor2tools/src/btorsplit.cpp:25:8: error: ‘uint32_t’ does not name a type
   25 | static uint32_t s_verbosity = 0;
btor2tools/src/btorsplit.cpp:22:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
```