### PR TITLE
Add exception stubs for successful compile to wasm.

### DIFF
--- a/src/btorsim/btorsim.cpp
+++ b/src/btorsim/btorsim.cpp
@@ -2036,3 +2036,16 @@ main (int32_t argc, char const *argv[])
     if (next_state[i].type) next_state[i].remove ();
   return 0;
 }
+
+#if defined(__wasm)
+extern "C" {
+	// FIXME: WASI does not currently support exceptions.
+	void* __cxa_allocate_exception(size_t thrown_size) throw() {
+		return malloc(thrown_size);
+	}
+	bool __cxa_uncaught_exception() throw();
+	void __cxa_throw(void* thrown_exception, struct std::type_info * tinfo, void (*dest)(void*)) {
+		std::terminate();
+	}
+}
+#endif

--- a/src/btorsplit.cpp
+++ b/src/btorsplit.cpp
@@ -175,3 +175,16 @@ main(int argc, char *argv[])
 
   return EXIT_SUCCESS;
 }
+
+#if defined(__wasm)
+extern "C" {
+	// FIXME: WASI does not currently support exceptions.
+	void* __cxa_allocate_exception(size_t thrown_size) throw() {
+		return malloc(thrown_size);
+	}
+	bool __cxa_uncaught_exception() throw();
+	void __cxa_throw(void* thrown_exception, struct std::type_info * tinfo, void (*dest)(void*)) {
+		std::terminate();
+	}
+}
+#endif


### PR DESCRIPTION
I [recently](https://github.com/cr1901/yowasp-boolector/actions/runs/7536963674/job/20515181787) got `boolector` to successfully compile for [WebAssembly](https://webassembly.org/).

I am using [local patches](https://github.com/cr1901/yowasp-boolector/blob/main/btor2tools.patch) for the time being, but this PR introduces my patches to upstream. This should be merged before the equivalent `boolector` PR.