### PR TITLE
Add BUILD_TOOLS option for building only libraries required by boolector.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ include(GNUInstallDirs)
 
 option(ASAN              "Compile with ASAN support" OFF)
 option(BUILD_BTOR2AIGER  "Build btor2aiger binary" OFF)
+option(BUILD_TOOLS       "Build btorsim, catbtor, btorsplit binaries" OFF)
 option(CHECK             "Enable assertions for optimized builds" OFF)
 option(BUILD_SHARED_LIBS "Build as shared library" ON)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,23 +10,28 @@ install(
   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
-add_executable(btorsim
-  btorsim/btorsimam.cpp
-  btorsim/btorsimstate.cpp
-  btorsim/btorsimvcd.cpp
-  btorsim/btorsimhelpers.cpp
-  btorsim/btorsim.cpp
-  btorsim/btorsimbv.c
-  btorsim/btorsimrng.c
-)
-target_include_directories(btorsim PRIVATE .)
-target_link_libraries(btorsim btor2parser)
-target_compile_options(btorsim PRIVATE -Wall -Wfatal-errors)
-install(TARGETS btorsim DESTINATION ${CMAKE_INSTALL_BINDIR})
+if (BUILD_TOOLS)
+  add_executable(btorsim
+    btorsim/btorsimam.cpp
+    btorsim/btorsimstate.cpp
+    btorsim/btorsimvcd.cpp
+    btorsim/btorsimhelpers.cpp
+    btorsim/btorsim.cpp
+    btorsim/btorsimbv.c
+    btorsim/btorsimrng.c
+  )
+  target_include_directories(btorsim PRIVATE .)
+  target_link_libraries(btorsim btor2parser)
+  target_compile_options(btorsim PRIVATE -Wall -Wfatal-errors)
+  install(TARGETS btorsim DESTINATION ${CMAKE_INSTALL_BINDIR})
 
-add_executable(catbtor catbtor.c)
-target_link_libraries(catbtor btor2parser)
-install(TARGETS catbtor DESTINATION ${CMAKE_INSTALL_BINDIR})
+  add_executable(catbtor catbtor.c)
+  target_link_libraries(catbtor btor2parser)
+  install(TARGETS catbtor DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+  add_executable(btorsplit btorsplit.cpp)
+  install(TARGETS btorsplit DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif()
 
 if(BUILD_BTOR2AIGER)
   add_executable(btor2aiger
@@ -38,6 +43,3 @@ if(BUILD_BTOR2AIGER)
   target_link_libraries(btor2aiger btor2parser Boolector::boolector)
   install(TARGETS btor2aiger DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
-
-add_executable(btorsplit btorsplit.cpp)
-install(TARGETS btorsplit DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
After discussing with YoWASP maintainer (@whitequark), we've decided this patch is better and supercedes/replaces #18. This PR adds a minimal build mode, so that only the minimum required dependencies for using `boolector` are built. This gets around the lack of WASM exceptions for the time being.

Original Context:

I [recently](https://github.com/cr1901/yowasp-boolector/actions/runs/7536963674/job/20515181787) got boolector to successfully compile for [WebAssembly](https://webassembly.org/).

I am using [local patches](https://github.com/cr1901/yowasp-boolector/blob/main/btor2tools.patch) for the time being, but this PR introduces my patches to upstream. This should be merged before the equivalent `boolector` PR.