### PR TITLE
Fixes and missing operator implementations for btorsim

### DIFF
--- a/src/btorsim/btorsim.cpp
+++ b/src/btorsim/btorsim.cpp
@@ -243,6 +243,7 @@ parse_model_line (Btor2Line *l)
     case BTOR2_TAG_implies:
     case BTOR2_TAG_inc:
     case BTOR2_TAG_ite:
+    case BTOR2_TAG_iff:
     case BTOR2_TAG_mul:
     case BTOR2_TAG_nand:
     case BTOR2_TAG_neg:

--- a/src/btorsim/btorsim.cpp
+++ b/src/btorsim/btorsim.cpp
@@ -257,6 +257,8 @@ parse_model_line (Btor2Line *l)
     case BTOR2_TAG_redand:
     case BTOR2_TAG_redor:
     case BTOR2_TAG_redxor:
+    case BTOR2_TAG_rol:
+    case BTOR2_TAG_ror:
     case BTOR2_TAG_sdiv:
     case BTOR2_TAG_sext:
     case BTOR2_TAG_sgt:
@@ -284,8 +286,6 @@ parse_model_line (Btor2Line *l)
 
     case BTOR2_TAG_fair:
     case BTOR2_TAG_justice:
-    case BTOR2_TAG_rol:
-    case BTOR2_TAG_ror:
     case BTOR2_TAG_saddo:
     case BTOR2_TAG_sdivo:
     case BTOR2_TAG_smod:
@@ -546,6 +546,20 @@ simulate (int64_t id)
         assert (res.type == BtorSimState::Type::BITVEC);
         assert (args[0].type == BtorSimState::Type::BITVEC);
         res.bv_state = btorsim_bv_redxor (args[0].bv_state);
+        break;
+      case BTOR2_TAG_rol:
+        assert (l->nargs == 2);
+        assert (res.type == BtorSimState::Type::BITVEC);
+        assert (args[0].type == BtorSimState::Type::BITVEC);
+        assert (args[1].type == BtorSimState::Type::BITVEC);
+        res.bv_state = btorsim_bv_rol (args[0].bv_state, args[1].bv_state);
+        break;
+      case BTOR2_TAG_ror:
+        assert (l->nargs == 2);
+        assert (res.type == BtorSimState::Type::BITVEC);
+        assert (args[0].type == BtorSimState::Type::BITVEC);
+        assert (args[1].type == BtorSimState::Type::BITVEC);
+        res.bv_state = btorsim_bv_ror (args[0].bv_state, args[1].bv_state);
         break;
       case BTOR2_TAG_slice:
         assert (l->nargs == 1);

--- a/src/btorsim/btorsim.cpp
+++ b/src/btorsim/btorsim.cpp
@@ -267,6 +267,7 @@ parse_model_line (Btor2Line *l)
     case BTOR2_TAG_sll:
     case BTOR2_TAG_slt:
     case BTOR2_TAG_slte:
+    case BTOR2_TAG_smod:
     case BTOR2_TAG_sra:
     case BTOR2_TAG_srem:
     case BTOR2_TAG_srl:
@@ -288,7 +289,6 @@ parse_model_line (Btor2Line *l)
     case BTOR2_TAG_justice:
     case BTOR2_TAG_saddo:
     case BTOR2_TAG_sdivo:
-    case BTOR2_TAG_smod:
     case BTOR2_TAG_smulo:
     case BTOR2_TAG_ssubo:
     case BTOR2_TAG_uaddo:
@@ -623,6 +623,13 @@ simulate (int64_t id)
         assert (args[0].type == BtorSimState::Type::BITVEC);
         assert (args[1].type == BtorSimState::Type::BITVEC);
         res.bv_state = btorsim_bv_sll (args[0].bv_state, args[1].bv_state);
+        break;
+      case BTOR2_TAG_smod:
+        assert (l->nargs == 2);
+        assert (res.type == BtorSimState::Type::BITVEC);
+        assert (args[0].type == BtorSimState::Type::BITVEC);
+        assert (args[1].type == BtorSimState::Type::BITVEC);
+        res.bv_state = btorsim_bv_smod (args[0].bv_state, args[1].bv_state);
         break;
       case BTOR2_TAG_srl:
         assert (l->nargs == 2);

--- a/src/btorsim/btorsimbv.c
+++ b/src/btorsim/btorsimbv.c
@@ -2042,7 +2042,7 @@ btorsim_bv_smod (const BtorSimBitVector *a, const BtorSimBitVector *b)
   assert (a->width == b->width);
 
   BtorSimBitVector *res = 0, *not_b, *sign_a, *sign_b, *neg_a, *neg_b, *add;
-  BtorSimBitVector *cond_a, *cond_b, *urem, *neg_urem, *add_urem, *add_neg_urem;
+  BtorSimBitVector *cond_a, *cond_b, *urem, *neg_urem;
   bool a_positive, b_positive;
 
   if (a->width == 1)
@@ -2071,12 +2071,10 @@ btorsim_bv_smod (const BtorSimBitVector *a, const BtorSimBitVector *b)
                                    : btorsim_bv_copy(b);
 
     neg_urem = btorsim_bv_neg (urem);
-    add_urem = btorsim_bv_add(urem, add);
-    add_neg_urem = btorsim_bv_add(neg_urem, add);
 
     res =  a_positive &&  b_positive ? btorsim_bv_copy(urem)
-        : !a_positive &&  b_positive ? btorsim_bv_copy(add_neg_urem)
-        :  a_positive && !b_positive ? btorsim_bv_copy(add_urem)
+        : !a_positive &&  b_positive ? btorsim_bv_add(neg_urem, add)
+        :  a_positive && !b_positive ? btorsim_bv_add(urem, add)
                                      : btorsim_bv_copy(neg_urem);
 
     btorsim_bv_free (sign_a);
@@ -2088,8 +2086,6 @@ btorsim_bv_smod (const BtorSimBitVector *a, const BtorSimBitVector *b)
     btorsim_bv_free (urem);
     btorsim_bv_free (add);
     btorsim_bv_free (neg_urem);
-    btorsim_bv_free (add_urem);
-    btorsim_bv_free (add_neg_urem);
   }
 
   assert (res);

--- a/src/btorsim/btorsimbv.c
+++ b/src/btorsim/btorsimbv.c
@@ -1754,6 +1754,38 @@ btorsim_bv_sra (const BtorSimBitVector *a, const BtorSimBitVector *b)
 }
 
 BtorSimBitVector *
+btorsim_bv_rol (const BtorSimBitVector *a, const BtorSimBitVector *b) {
+  BtorSimBitVector *width = btorsim_bv_uint64_to_bv(a->width, a->width);
+  BtorSimBitVector *rev = btorsim_bv_sub(width, b);
+
+  BtorSimBitVector *sll_part = btorsim_bv_sll(a, b);
+  BtorSimBitVector *srl_part = btorsim_bv_srl(a, rev);
+  BtorSimBitVector *res = btorsim_bv_or(sll_part, srl_part);
+
+  btorsim_bv_free(width);
+  btorsim_bv_free(rev);
+  btorsim_bv_free(sll_part);
+  btorsim_bv_free(srl_part);
+  return res;
+}
+
+BtorSimBitVector *
+btorsim_bv_ror (const BtorSimBitVector *a, const BtorSimBitVector *b) {
+  BtorSimBitVector *width = btorsim_bv_uint64_to_bv(a->width, a->width);
+  BtorSimBitVector *rev = btorsim_bv_sub(width, b);
+
+  BtorSimBitVector *srl_part = btorsim_bv_srl(a, b);
+  BtorSimBitVector *sll_part = btorsim_bv_sll(a, rev);
+  BtorSimBitVector *res = btorsim_bv_or(srl_part, sll_part);
+
+  btorsim_bv_free(width);
+  btorsim_bv_free(rev);
+  btorsim_bv_free(srl_part);
+  btorsim_bv_free(sll_part);
+  return res;
+}
+
+BtorSimBitVector *
 btorsim_bv_mul (const BtorSimBitVector *a, const BtorSimBitVector *b)
 {
   assert (a);

--- a/src/btorsim/btorsimbv.c
+++ b/src/btorsim/btorsimbv.c
@@ -1736,15 +1736,15 @@ btorsim_bv_sra (const BtorSimBitVector *a, const BtorSimBitVector *b)
   assert (a->len == b->len);
   assert (a->width == b->width);
 
-  BtorSimBitVector *res, *sign_b, *srl1, *srl2, *not_a;
+  BtorSimBitVector *res, *sign_a, *srl1, *srl2, *not_a;
 
-  sign_b = btorsim_bv_slice (b, b->width - 1, b->width - 1);
+  sign_a = btorsim_bv_slice (a, a->width - 1, a->width - 1);
   srl1   = btorsim_bv_srl (a, b);
   not_a  = btorsim_bv_not (a);
   srl2   = btorsim_bv_srl (not_a, b);
-  res    = btorsim_bv_is_true (not_a) ? btorsim_bv_not (srl2)
+  res    = btorsim_bv_is_true (sign_a) ? btorsim_bv_not (srl2)
                                       : btorsim_bv_copy (srl1);
-  btorsim_bv_free (sign_b);
+  btorsim_bv_free (sign_a);
   btorsim_bv_free (srl1);
   btorsim_bv_free (srl2);
   btorsim_bv_free (not_a);

--- a/src/btorsim/btorsimbv.h
+++ b/src/btorsim/btorsimbv.h
@@ -212,6 +212,9 @@ BtorSimBitVector *btorsim_bv_urem (const BtorSimBitVector *a,
 BtorSimBitVector *btorsim_bv_srem (const BtorSimBitVector *a,
                                    const BtorSimBitVector *b);
 
+BtorSimBitVector *btorsim_bv_smod (const BtorSimBitVector *a,
+                                   const BtorSimBitVector *b);
+
 BtorSimBitVector *btorsim_bv_ite (const BtorSimBitVector *c,
                                   const BtorSimBitVector *t,
                                   const BtorSimBitVector *e);

--- a/src/btorsim/btorsimbv.h
+++ b/src/btorsim/btorsimbv.h
@@ -191,6 +191,12 @@ BtorSimBitVector *btorsim_bv_srl (const BtorSimBitVector *a,
 BtorSimBitVector *btorsim_bv_sra (const BtorSimBitVector *a,
                                   const BtorSimBitVector *b);
 
+BtorSimBitVector *btorsim_bv_rol (const BtorSimBitVector *a,
+                                  const BtorSimBitVector *b);
+
+BtorSimBitVector *btorsim_bv_ror (const BtorSimBitVector *a,
+                                  const BtorSimBitVector *b);
+
 BtorSimBitVector *btorsim_bv_mul (const BtorSimBitVector *a,
                                   const BtorSimBitVector *b);
 


### PR DESCRIPTION
This PR implements the missing operations `iff`, `rol`, `ror`, and `smod` in btorsim and fixes the implementation for `sra`.

Btorsim already has an implementation for iff, but it wasn't marked as implemented.

Implement rol and ror by delegating to sll and srl and or-ing the results together.

Smod implementation taken from boolector ([src/btorexp.c:1528](https://github.com/Boolector/boolector/blob/6603ed7b8d401f9bf387f32c702e3e938c50924d/src/btorexp.c#L1528))

The previous sra implementation wasn't working for negative inputs. The implementation was extracting the wrong sign bit (from b instead of a) and also accidently forgot to use it in the conditional, and used not_a instead.

This fixes #22, fixes #23, and fixes #24